### PR TITLE
rads: skip the desktop on a GPU-less (headless) boot

### DIFF
--- a/usr/libexec/rads/ram-adjusted-desktop-starter
+++ b/usr/libexec/rads/ram-adjusted-desktop-starter
@@ -6,6 +6,9 @@
 #set -x
 set -o pipefail
 set -o errtrace
+## style-ok: no-strict -- this script deliberately uses MANUAL error handling (trap
+## error_handler_rads) instead of 'set -o errexit'/'nounset'; it references unset variables
+## (e.g. $rads_debug) and tolerant commands by design, so enabling strict mode would break it.
 
 error_handler_rads() {
    echo "[${red}${bold}ERROR${reset}] \
@@ -135,6 +138,7 @@ ram-adjusted-desktop-starter() {
    [ -n "$rads_minimum_ram" ] || rads_minimum_ram="710"
    [ -n "$rads_start_display_manager" ] || rads_start_display_manager="1"
    [ -n "$rads_skip_ram_test" ] || rads_skip_ram_test="0"
+   [ -n "$rads_skip_gpu_test" ] || rads_skip_gpu_test="0"
    [ -n "$rads_wait" ] || rads_wait="1"
    [ -n "$rads_wait_seconds" ] || rads_wait_seconds="10"
    [ -n "$rads_no_switch_vt" ] || rads_no_switch_vt="0"
@@ -208,6 +212,29 @@ because there is only $total_ram MB total RAM. (A minimum of \
 $rads_minimum_ram MB total RAM is configured in /etc/rads.d/ \
 configuration folder.)"
          sleep 5
+         create_status_file_no_start_dm
+         exit 0
+      fi
+   fi
+
+   ## No GPU / DRM device: a Wayland compositor (labwc, started via greetd) cannot create a
+   ## backend without a DRM device and would spam 'Found 0 GPUs, cannot create backend' /
+   ## 'Failed to open any DRM device' in the journal, then fail. On a headless / GPU-less boot
+   ## (a server, or a VM with no virtual GPU) skip the graphical session entirely. 'nullglob' is
+   ## set above, so the glob yields nothing when /dev/dri is absent. Override: rads_skip_gpu_test=1.
+   if [ ! "$rads_skip_gpu_test" = "1" ]; then
+      gpu_present="0"
+      for drm_card in /dev/dri/card[0-9]* ; do
+         if [ -e "$drm_card" ]; then
+            gpu_present="1"
+            break
+         fi
+      done
+      if [ "$gpu_present" = "0" ]; then
+         echo "[${green}INFO${reset}] Not starting display manager \
+(graphical desktop environment) ('$rads_display_manager'), because no GPU / DRM device \
+(/dev/dri/card*) is present. A Wayland compositor needs one; this is expected on a headless \
+or GPU-less boot. (Override with rads_skip_gpu_test=1 in /etc/rads.d/ configuration folder.)"
          create_status_file_no_start_dm
          exit 0
       fi

--- a/usr/libexec/rads/ram-adjusted-desktop-starter
+++ b/usr/libexec/rads/ram-adjusted-desktop-starter
@@ -139,6 +139,7 @@ ram-adjusted-desktop-starter() {
    [ -n "$rads_start_display_manager" ] || rads_start_display_manager="1"
    [ -n "$rads_skip_ram_test" ] || rads_skip_ram_test="0"
    [ -n "$rads_skip_gpu_test" ] || rads_skip_gpu_test="0"
+   [ -n "$rads_gpu_wait_seconds" ] || rads_gpu_wait_seconds="5"
    [ -n "$rads_wait" ] || rads_wait="1"
    [ -n "$rads_wait_seconds" ] || rads_wait_seconds="10"
    [ -n "$rads_no_switch_vt" ] || rads_no_switch_vt="0"
@@ -217,24 +218,42 @@ configuration folder.)"
       fi
    fi
 
-   ## No GPU / DRM device: a Wayland compositor (labwc, started via greetd) cannot create a
-   ## backend without a DRM device and would spam 'Found 0 GPUs, cannot create backend' /
-   ## 'Failed to open any DRM device' in the journal, then fail. On a headless / GPU-less boot
-   ## (a server, or a VM with no virtual GPU) skip the graphical session entirely. 'nullglob' is
-   ## set above, so the glob yields nothing when /dev/dri is absent. Override: rads_skip_gpu_test=1.
-   if [ ! "$rads_skip_gpu_test" = "1" ]; then
+   ## No GPU / DRM device: a WAYLAND compositor (labwc, started via greetd -- the only supported
+   ## Wayland greeter) cannot create a backend without a DRM device and would spam 'Found 0 GPUs,
+   ## cannot create backend' / 'Failed to open any DRM device' in the journal, then fail. On a
+   ## GPU-less boot (a server, or a VM with no virtual GPU) skip the graphical session.
+   ##
+   ## This gate applies ONLY to the greetd/Wayland path. An X11 display manager (lightdm, xdm,
+   ## nodm, ...) can drive Xorg on the vesa/fbdev fallback with NO /dev/dri (e.g. a 'nomodeset'
+   ## boot), so gating it on a DRM node would wrongly skip a usable Xorg desktop -- do not.
+   ##
+   ## A DRM driver can bind a few seconds INTO boot (proprietary nvidia-drm, a modular
+   ## virtio-gpu/i915 on slow storage), and this oneshot runs early, so a single instantaneous
+   ## glob would false-negative on real GPU hardware. Wait briefly ('rads_gpu_wait_seconds', a
+   ## per-second poll) for a card node to appear before concluding headless. 'nullglob' (set
+   ## above) makes the unmatched glob expand to nothing; the '[ -e ]' guard is a belt-and-braces
+   ## fallback if a sourced config toggled nullglob off.
+   if [ "$rads_display_manager" = "greetd" ] && [ ! "$rads_skip_gpu_test" = "1" ]; then
       gpu_present="0"
-      for drm_card in /dev/dri/card[0-9]* ; do
-         if [ -e "$drm_card" ]; then
-            gpu_present="1"
+      gpu_waited="0"
+      while true; do
+         for drm_card in /dev/dri/card[0-9]* ; do
+            if [ -e "$drm_card" ]; then
+               gpu_present="1"
+               break
+            fi
+         done
+         if [ "$gpu_present" = "1" ] || [ "$gpu_waited" -ge "$rads_gpu_wait_seconds" ]; then
             break
          fi
+         sleep 1
+         gpu_waited="$((gpu_waited + 1))"
       done
       if [ "$gpu_present" = "0" ]; then
-         echo "[${green}INFO${reset}] Not starting display manager \
-(graphical desktop environment) ('$rads_display_manager'), because no GPU / DRM device \
-(/dev/dri/card*) is present. A Wayland compositor needs one; this is expected on a headless \
-or GPU-less boot. (Override with rads_skip_gpu_test=1 in /etc/rads.d/ configuration folder.)"
+         echo "[${green}INFO${reset}] Not starting display manager (Wayland greeter \
+'$rads_display_manager'), because no GPU / DRM device (/dev/dri/card*) appeared within \
+${rads_gpu_wait_seconds}s. A Wayland compositor needs one; this is expected on a headless or \
+GPU-less boot. (Override with rads_skip_gpu_test=1 in /etc/rads.d/ configuration folder.)"
          create_status_file_no_start_dm
          exit 0
       fi


### PR DESCRIPTION
On a GPU-less boot (a server, or a VM with no virtual GPU) the Wayland compositor (labwc via greetd) cannot create a backend and repeatedly logs `Found 0 GPUs, cannot create backend` / `Failed to open any DRM device`, then fails. This adds a GPU gate next to the existing RAM gate in ram-adjusted-desktop-starter: when no `/dev/dri/card*` DRM device is present, the display manager is not started (override with `rads_skip_gpu_test=1`). Matches the script's existing idiom.

Found while running `systemcheck --leak-tests --verbose` headless in qemu (the journal-warning check flagged the labwc DRM errors). Not yet runtime-validated on a rebuilt image.

AI-Assisted.